### PR TITLE
Migrate from flutter_ffmpeg to ffmpeg-kit

### DIFF
--- a/yuuna/android/build.gradle
+++ b/yuuna/android/build.gradle
@@ -31,7 +31,3 @@ subprojects {
 tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }
-
-ext {
-    flutterFFmpegPackage = "full-gpl-lts"
-}

--- a/yuuna/lib/src/media/source_types/player_media_source.dart
+++ b/yuuna/lib/src/media/source_types/player_media_source.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:ffmpeg_kit_flutter/ffmpeg_session.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_ffmpeg/flutter_ffmpeg.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_vlc_player/flutter_vlc_player.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -170,10 +171,8 @@ abstract class PlayerMediaSource extends MediaSource {
       String command =
           '-ss $timestamp -y -i "$inputPath" -frames:v 1 -q:v 2 "$outputPath"';
 
-      final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
-      await flutterFFmpeg.execute(command);
-
-      String output = await FlutterFFmpegConfig().getLastCommandOutput();
+      FFmpegSession session = await FFmpegKit.execute(command);
+      String output = await session.getOutput() ?? '';
 
       if (!output.contains('Output file is empty, nothing was encoded')) {
         while (!imageFile.existsSync()) {
@@ -263,8 +262,7 @@ abstract class PlayerMediaSource extends MediaSource {
     String command =
         '-ss $timeStart -to $timeEnd -y -i "$inputPath" -map 0:a:$audioIndex "$outputPath"';
 
-    final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
-    await flutterFFmpeg.execute(command);
+    await FFmpegKit.execute(command);
 
     return audioFile;
   }

--- a/yuuna/lib/src/media/sources/player_local_media_source.dart
+++ b/yuuna/lib/src/media/sources/player_local_media_source.dart
@@ -2,8 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:collection/collection.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_ffmpeg/flutter_ffmpeg.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_session.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_vlc_player/flutter_vlc_player.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
@@ -99,13 +100,12 @@ class PlayerLocalMediaSource extends PlayerMediaSource {
   Future<void> generateThumbnail(String inputPath, String targetPath) async {
     String timestamp =
         JidoujishoTimeFormat.getFfmpegTimestamp(const Duration(seconds: 30));
-    final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
 
     String command =
         '-ss $timestamp -y -i "$inputPath" -frames:v 1 -q:v 2 "$targetPath"';
 
-    await flutterFFmpeg.execute(command);
-    String output = await FlutterFFmpegConfig().getLastCommandOutput();
+    FFmpegSession session = await FFmpegKit.execute(command);
+    String output = await session.getOutput() ?? '';
 
     if (output.contains('Output file is empty, nothing was encoded')) {
       String timestamp =
@@ -113,7 +113,7 @@ class PlayerLocalMediaSource extends PlayerMediaSource {
 
       String command =
           '-ss $timestamp -y -i "$inputPath" -frames:v 1 -q:v 2 "$targetPath"';
-      await flutterFFmpeg.execute(command);
+      await FFmpegKit.execute(command);
     }
   }
 

--- a/yuuna/lib/src/utils/player/subtitle_utils.dart
+++ b/yuuna/lib/src/utils/player/subtitle_utils.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
-import 'package:flutter_ffmpeg/flutter_ffmpeg.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_kit.dart';
+import 'package:ffmpeg_kit_flutter/ffmpeg_session.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:subtitle/subtitle.dart';
 import 'package:path/path.dart' as path;
@@ -139,9 +140,7 @@ class SubtitleUtils {
       outputFile.deleteSync();
     }
 
-    final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
-
-    await flutterFFmpeg.execute(command);
+    await FFmpegKit.execute(command);
 
     await Future.delayed(const Duration(seconds: 1));
 
@@ -185,11 +184,8 @@ class SubtitleUtils {
         outputFile.deleteSync();
       }
 
-      final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
-      final FlutterFFmpegConfig flutterFFmpegConfig = FlutterFFmpegConfig();
-
-      await flutterFFmpeg.execute(command);
-      String output = await flutterFFmpegConfig.getLastCommandOutput();
+      FFmpegSession session = await FFmpegKit.execute(command);
+      String output = await session.getOutput() ?? '';
       if (output.contains("Stream map '0:s:$i' matches no streams.")) {
         break;
       }
@@ -227,9 +223,7 @@ class SubtitleUtils {
 
     String command = '-i "$inputPath" "$outputPath"';
 
-    final FlutterFFmpeg flutterFFmpeg = FlutterFFmpeg();
-
-    await flutterFFmpeg.execute(command);
+    await FFmpegKit.execute(command);
 
     return targetFile.readAsStringSync();
   }

--- a/yuuna/pubspec.lock
+++ b/yuuna/pubspec.lock
@@ -498,6 +498,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  ffmpeg_kit_flutter:
+    dependency: "direct main"
+    description:
+      name: ffmpeg_kit_flutter
+      sha256: b7c874eeffd2c554d636a84a9fbdfe34a99a5862ad636d4779b4b7f56060d728
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.3-LTS"
+  ffmpeg_kit_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: ffmpeg_kit_flutter_platform_interface
+      sha256: addf046ae44e190ad0101b2fde2ad909a3cd08a2a109f6106d2f7048b7abedee
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   file:
     dependency: transitive
     description:
@@ -616,14 +632,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  flutter_ffmpeg:
-    dependency: "direct main"
-    description:
-      name: flutter_ffmpeg
-      sha256: "8d8bb4551cf76384748ba6948739c1e56a9164794e48f06cbfb0ff1bfb058b5f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.2"
   flutter_gpt_tokenizer:
     dependency: "direct main"
     description:
@@ -1099,10 +1107,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   marquee:
     dependency: "direct main"
     description:

--- a/yuuna/pubspec.yaml
+++ b/yuuna/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   external_app_launcher: ^3.1.0
   external_path: ^1.0.1
   favicon: ^1.1.1
+  ffmpeg_kit_flutter: 6.0.3-LTS
   file_picker: ^5.3.0
   filesystem_picker:
     git:
@@ -47,7 +48,6 @@ dependencies:
   flutter_charset_detector: ^1.0.2
   flutter_colorpicker: ^1.0.3
   flutter_exit_app: ^1.0.5
-  flutter_ffmpeg: ^0.4.2
   flutter_gpt_tokenizer: ^0.1.0
   flutter_html: ^3.0.0-beta.2
   flutter_html_table: ^3.0.0-beta.2


### PR DESCRIPTION
`flutter_ffmpeg` was deprecated and is now causing builds to fail so I updated the repo to use `ffmpeg-kit` instead. Luckily, the APIs were extremely similar and the change was relatively simple